### PR TITLE
Allowing History/Favorite deletion from their respective page.

### DIFF
--- a/include/frontend/pages/Favorites.h
+++ b/include/frontend/pages/Favorites.h
@@ -1,10 +1,10 @@
 #ifndef FRONTEND_PAGE_FAVORITES
 #define FRONTEND_PAGE_FAVORITES
 
+#include "dictionary/history.h"
 #include "dictionary/word.h"
 #include "frontend/styles.h"
 #include "globalVars/globalVars.h"
-#include "dictionary/history.h"
 #include "raylib.h"
 #include <vector>
 
@@ -14,6 +14,8 @@ class FavoritesPage
     std::vector<Word> words;
     std::vector<std::string> wordStrings;
     std::vector<Rectangle> wordRects;
+    std::vector<Rectangle> deleteRects;
+
     Rectangle dictChooserRect{1075, 140, 155, 55};
     std::vector<std::string> dictLanguages = {"ENG-ENG", "ENG-VIE", "VIE-ENG", "EMOJI", "SLANG"};
 
@@ -22,15 +24,19 @@ class FavoritesPage
 
     short int selectedDictPage = 2;
     bool dictChooserActive     = false;
+    bool confirmDeleteRecordBox = false;
 
     // Both history and favorites uses the same function
     History currentFavorites = History(favoritesDirectories[*CurrentState::currentDict], 1);
-    Trie currentTrie = PrebuiltTriesList[*CurrentState::currentDict];
+    Trie currentTrie         = PrebuiltTriesList[*CurrentState::currentDict];
+
   public:
     FavoritesPage();
-  std::string TextEllipsis(const std::string &text, const Font &font, float maxWidth);
+    std::string TextEllipsis(const std::string &text, const Font &font, float maxWidth);
     void update();
     void draw();
+    void getFavorites(std::vector<std::string> wordStrings);
+    void deleteRecord();
 };
 
 #endif

--- a/include/frontend/pages/History.h
+++ b/include/frontend/pages/History.h
@@ -14,6 +14,8 @@ class HistoryPage
     std::vector<Word> words;
     std::vector <std::string> wordStrings;
     std::vector<Rectangle> wordRects;
+    std::vector<Rectangle> deleteRects;
+
     Rectangle dictChooserRect{1075, 140, 155, 55};
     std::vector<std::string> dictLanguages = {"ENG-ENG", "ENG-VIE", "VIE-ENG", "EMOJI", "SLANG"};
 
@@ -28,11 +30,14 @@ class HistoryPage
     // Create the storage
     History currentHistory = History(historyDirectories[*CurrentState::currentDict]);
     Trie currentTrie = PrebuiltTriesList[*CurrentState::currentDict];
+    bool confirmDeleteRecordBox = false;
   public:
     HistoryPage();
     std::string TextEllipsis(const std::string &text, const Font &font, float maxWidth);
     void update();
     void draw();
+    void deleteRecord();
+    void getHistory(std::vector<std::string> wordStrings);
 };
 
 #endif

--- a/src/frontend/pages/History.cpp
+++ b/src/frontend/pages/History.cpp
@@ -15,7 +15,7 @@ HistoryPage::HistoryPage()
 
     for (int i = 0; i < words.size(); i++)
     {
-            wordRects.push_back({307, float(225 + 130 * i), 921, 120});
+        wordRects.push_back({307, float(225 + 130 * i), 921, 120});
     }
 }
 // Truncate the text and add ellipsis if it exceeds the specified width
@@ -44,8 +44,6 @@ std::string HistoryPage::TextEllipsis(const std::string &text, const Font &font,
     return truncatedText;
 }
 
-
-
 void HistoryPage::update()
 {
     currentHistory = History(historyDirectories[*CurrentState::currentDict]);
@@ -54,26 +52,15 @@ void HistoryPage::update()
         // Get the history strings
         wordStrings = currentHistory.get();
 
-        // Search through the trie for the words
-        for (int i = 0; i < wordStrings.size(); i++)
-        {
-            Word tmp;
-
-            currentTrie.search(wordStrings[i], tmp);
-            if (tmp.getKey() != "")
-            {
-                words.push_back(tmp);
-                wordRects.push_back({307, float(225 + 130 * i), 921, 120});
-            }
-
-        }
+        getHistory(wordStrings);
     }
 
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !dictChooserActive)
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !dictChooserActive && !confirmDeleteRecordBox)
     {
         for (int i = 0; i < words.size(); ++i)
         {
-            if (GetMousePosition().y > 180 && CheckCollisionPointRec(GetMousePosition(), wordRects[i]))
+            if (GetMousePosition().y > 180 && CheckCollisionPointRec(GetMousePosition(), wordRects[i]) &&
+                !CheckCollisionPointRec(GetMousePosition(), deleteRects[i]))
             {
                 CurrentState::currentWord = words[i];
                 CurrentState::currentPage = static_cast<Page>(5);
@@ -89,50 +76,58 @@ void HistoryPage::update()
         }
     }
 
-    if ((IsKeyPressed(KEY_DOWN)) || GetMouseWheelMove() == -1 && wordRects[words.size() - 1].y + wordRects[words.size() - 1].height > 800)
+    if ((IsKeyPressed(KEY_DOWN)) ||
+        GetMouseWheelMove() == -1 && wordRects[words.size() - 1].y + wordRects[words.size() - 1].height > 800)
     {
         for (int i = 0; i < words.size(); i++)
         {
             wordRects[i].y -= 40;
         }
     }
-
 }
 
 void HistoryPage::draw()
 {
+
+    if (confirmDeleteRecordBox)
+    {
+        deleteRecord();
+        return;
+    }
     Vector2 mousePos = GetMousePosition();
     // Draw the Search Box (disabled)
     DrawRectangle(305, 140, 420, 55, BG_COLOR_RGB);
-   // Draws each word
+    // Draws each word
     for (int i = 0; i < words.size(); i++)
     {
         std::string wordWithTypeTmp = words[i].getKey();
-        if(!words[i].getType().empty())
+        if (!words[i].getType().empty())
         {
             wordWithTypeTmp += " (" + words[i].getType() + ")";
         }
 
-        DrawRectangleGradientV(wordRects[i].x, wordRects[i].y, wordRects[i].width, wordRects[i].height, BOX_COLOR_RGB, BOX_COLOR_RGB); 
+        DrawRectangleGradientV(wordRects[i].x, wordRects[i].y, wordRects[i].width, wordRects[i].height, BOX_COLOR_RGB,
+                               BOX_COLOR_RGB);
 
-/*         DrawRectangleV({wordRects[i].x, wordRects[i].y}, {wordRects[i].width, wordRects[i].height},
-                       SECONDARY_COLOR_CONTAINER_RGB);
-        DrawRectangleLinesEx(wordRects[i], 2, OUTLINE_COLOR_RGB); */
+        /*         DrawRectangleV({wordRects[i].x, wordRects[i].y}, {wordRects[i].width, wordRects[i].height},
+                               SECONDARY_COLOR_CONTAINER_RGB);
+                DrawRectangleLinesEx(wordRects[i], 2, OUTLINE_COLOR_RGB); */
 
-        if (CheckCollisionPointRec(mousePos, wordRects[i]) && mousePos.y > 180 && !dictChooserActive)
+        if (CheckCollisionPointRec(mousePos, wordRects[i]) && !CheckCollisionPointRec(mousePos, deleteRects[i]) &&
+            mousePos.y > 180 && !dictChooserActive)
+        {
             DrawRectangleGradientV(wordRects[i].x, wordRects[i].y, wordRects[i].width, wordRects[i].height,
                                    GetColor(RESULT_COLOR_CONTAINER_HOVER), GetColor(RESULT_COLOR_CONTAINER_HOVER));
+        }
 
-/*         if (CheckCollisionPointRec(mousePos, wordRects[i]) && !dictChooserActive)
-        {
-            DrawRectangleV({wordRects[i].x, wordRects[i].y}, {wordRects[i].width, wordRects[i].height},
-                           SECONDARY_COLOR_RGB);
-        } */
+        /*         if (CheckCollisionPointRec(mousePos, wordRects[i]) && !dictChooserActive)
+                {
+                    DrawRectangleV({wordRects[i].x, wordRects[i].y}, {wordRects[i].width, wordRects[i].height},
+                                   SECONDARY_COLOR_RGB);
+                } */
 
         Vector2 textPosition = {wordRects[i].x + 10, wordRects[i].y + 10};
-        DrawTextEx(Resources::wordFontBold, wordWithTypeTmp.c_str(),textPosition,
-                   WORD_FONT_SIZE, 0, TEXT_COLOR_RGB);
-
+        DrawTextEx(Resources::wordFontBold, wordWithTypeTmp.c_str(), textPosition, WORD_FONT_SIZE, 0, TEXT_COLOR_RGB);
 
         for (int j = 0; j < std::min(2, int(words[i].getDefinitionCount())); j++)
         {
@@ -163,6 +158,12 @@ void HistoryPage::draw()
                            TEXT_COLOR_RGB);
             }
         }
+
+        if (GuiButton({wordRects[i].x + 850, wordRects[i].y + 10, 30, 30}, "#143#"))
+        {
+            CurrentState::currentWord = words[i];
+            confirmDeleteRecordBox    = true;
+        }
     }
     // Function switcher container
     DrawRectangleV(Vector2{0, 0}, Vector2{277, 720}, GetColor(SECONDARY_COLOR));
@@ -184,24 +185,76 @@ void HistoryPage::draw()
         }
     }
 
-
     // Draw the Dict Picker
-    if (GuiDropdownBox(
-            dictChooserRect,
-            (dictLanguages[0] + "\n" + dictLanguages[1] + "\n" + dictLanguages[2] + "\n" + dictLanguages[3] + "\n" + dictLanguages[4]).c_str(),
-            CurrentState::currentDict, dictChooserActive))
+    if (GuiDropdownBox(dictChooserRect,
+                       (dictLanguages[0] + "\n" + dictLanguages[1] + "\n" + dictLanguages[2] + "\n" + dictLanguages[3] +
+                        "\n" + dictLanguages[4])
+                           .c_str(),
+                       CurrentState::currentDict, dictChooserActive))
     {
         dictChooserActive ^= 1;
 
         // Update the trie object
         currentTrie = PrebuiltTriesList[*CurrentState::currentDict];
-        
+
         words.clear();
         wordStrings.clear();
 
         currentHistory.save();
         currentHistory = History(historyDirectories[*CurrentState::currentDict]);
     }
+}
 
-    
+void HistoryPage::deleteRecord()
+{
+    if (GuiWindowBox({300, 170, 600, 250}, ""))
+    {
+        confirmDeleteRecordBox = false;
+    }
+    std::string promptText = "Are you sure you want to delete this from your history?";
+    DrawTextEx(Resources::displayFontRegular, promptText.c_str(),
+               {850 - MeasureTextEx(Resources::displayFontRegular, promptText.c_str(), TEXT_FONT_SIZE, 0).x, 220},
+               TEXT_FONT_SIZE, 0, TEXT_COLOR_RGB);
+    DrawTextEx(Resources::wordFontRegular, CurrentState::currentWord.getKey().c_str(), {620, 260}, WORD_FONT_SIZE, 0,
+               TEXT_COLOR_RGB);
+    if (GuiButton({400, 330, 100, 50}, "YES"))
+    {
+
+        // Delete the word from the history
+        if (currentHistory.find(CurrentState::currentWord.getKey()))
+        {
+            currentHistory.remove(CurrentState::currentWord.getKey());
+        }
+        currentHistory.save();
+
+        // Update the words vector
+        words.clear();
+        wordStrings.clear();
+
+        getHistory(currentHistory.get());
+
+        CurrentState::currentWord = Word();
+        confirmDeleteRecordBox    = false;
+    }
+    if (GuiButton({700, 330, 100, 50}, "NO"))
+    {
+        confirmDeleteRecordBox = false;
+    }
+}
+
+void HistoryPage::getHistory(std::vector<std::string> wordStrings)
+{
+    // Search through the trie for the words
+    for (int i = 0; i < wordStrings.size(); i++)
+    {
+        Word tmp;
+
+        currentTrie.search(wordStrings[i], tmp);
+        if (tmp.getKey() != "")
+        {
+            words.push_back(tmp);
+            wordRects.push_back({307, float(225 + 130 * i), 921, 120});
+            deleteRects.push_back({wordRects[i].x + 850, wordRects[i].y + 10, 30, 30});
+        }
+    }
 }


### PR DESCRIPTION
- In the History and Favorite page, each word will have a tiny trash can, which, when clicked, will prompt for deletion.
- Accommodating it are some styling changes, and some code simplification.